### PR TITLE
Use environment variables for local Postgres credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,12 @@
+# Local PostgreSQL settings used by docker-compose.yml.
+# Copy this file to .env and replace POSTGRES_PASSWORD before sharing
+# screenshots, examples, or deployment configs.
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=change_me
+POSTGRES_DB=pragmatic-papers
+
 # Database connection string
-DATABASE_URI=postgres://postgres:postgres@localhost:9000/pragmatic-papers
+DATABASE_URI=postgres://postgres:change_me@localhost:9000/pragmatic-papers
 
 # Used to encrypt JWT tokens
 PAYLOAD_SECRET=YOUR_SECRET_HERE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,15 @@ services:
     image: postgres:17-alpine
     restart: always
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: pragmatic-papers
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running docker compose}
+      POSTGRES_DB: ${POSTGRES_DB:-pragmatic-papers}
     ports:
       - "9000:5432"
     volumes:
       - pragmatic_papers_postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d pragmatic-papers"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
Summary:
- Move local Postgres credentials in docker-compose.yml to environment variables
- Require POSTGRES_PASSWORD to be set before Docker Compose starts
- Update .env.example with the matching local Postgres variables and placeholder password

Verification:
- POSTGRES_PASSWORD=change_me docker compose config --quiet
- git diff --check

Closes #789