### PR TITLE
fix(fonts): fail deploy builds instead of silently shipping the Inter fallback

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -55,6 +55,12 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
 
+    env:
+      # Baselines captured with the Inter fallback would bake the wrong typeface into every
+      # future visual diff, so fail the run rather than commit bad screenshots. Job-level so
+      # it reaches the install step inside the setup-project composite action.
+      FONTS_REQUIRED: "true"
+
     permissions:
       contents: write
       pull-requests: write

--- a/dockerfiles/.env.example
+++ b/dockerfiles/.env.example
@@ -34,6 +34,12 @@ COOLIFY_FQDN=
 
 # GitHub Packages PAT with read:packages scope (for @digitalgroundgame fonts)
 # COOLIFY: Build + Build Secrets
+# NOTE: PATs expire. When this token lapses the build does NOT fail on its own — the
+# private package is an optionalDependency, so pnpm skips it and the site silently ships
+# the bundled Inter fallback instead of FKScreamer. The Dockerfile sets FONTS_REQUIRED=true
+# so deploy builds fail loudly instead; see scripts/install-fonts.ts.
+# After rotating the token, rebuild WITHOUT cache — the pnpm store is a cache mount keyed on
+# the lockfile, so a normal rebuild reuses a store that is still missing the font package.
 GH_FONT_READ=YOUR_GITHUB_TOKEN_HERE
 
 # COOLIFY: Build + Runtime + Build Secrets

--- a/dockerfiles/PragmaticPapers.Dockerfile
+++ b/dockerfiles/PragmaticPapers.Dockerfile
@@ -43,6 +43,12 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 COPY package.json ./
 COPY scripts/install-fonts.ts scripts/ansi.mjs scripts/Inter-Bold.woff2 ./scripts/
 
+# A deploy must ship the real FKScreamer. Without this, an expired or unscoped
+# GH_FONT_READ degrades to the bundled Inter fallback and the build still succeeds —
+# shipping the wrong typeface. install-fonts.ts exits non-zero instead. Builder stage
+# only, so local installs and fork CI keep the lenient fallback.
+ENV FONTS_REQUIRED=true
+
 # 4. Install dependencies from the store (offline)
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     echo "--- PHASE: INSTALLING DEPENDENCIES (OFFLINE) ---" \

--- a/scripts/install-fonts.ts
+++ b/scripts/install-fonts.ts
@@ -2,12 +2,20 @@ import { cpSync, existsSync, mkdirSync, readFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import process from "node:process"
 import { fileURLToPath } from "node:url"
-import { blue, gray, green, yellow } from "./ansi.mjs"
+import { blue, gray, green, red, yellow } from "./ansi.mjs"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = process.cwd()
 
 const fallbackFont = resolve(__dirname, "Inter-Bold.woff2")
+
+/**
+ * Deploy builds must ship the real FKScreamer. The Inter fallback keeps `pnpm install`
+ * working for contributors without access to the private package, but on a deploy it
+ * silently renders the wrong typeface behind a green build — so fail loudly instead.
+ * Set by dockerfiles/PragmaticPapers.Dockerfile (Coolify) and the snapshot workflow.
+ */
+const fontsRequired = process.env.FONTS_REQUIRED === "true"
 
 const src = resolve(
   root,
@@ -25,10 +33,15 @@ if (existsSync(src)) {
   process.exit(0)
 }
 
-// Inter-Bold.woff2 fallback is ~74KB; anything under 1000 bytes is a stale empty placeholder
+// Inter-Bold.woff2 fallback is ~24KB; anything under 1000 bytes is a stale empty placeholder.
+// A previous run's fallback also clears that bar, so compare bytes rather than trusting the
+// size alone — otherwise a stale Inter reports itself as "real" and skips the check below.
 if (existsSync(fontPath) && readFileSync(fontPath).byteLength > 1000) {
-  console.warn(gray("○ Fonts already installed (real)"))
-  process.exit(0)
+  if (!readFileSync(fontPath).equals(readFileSync(fallbackFont))) {
+    console.warn(gray("○ Fonts already installed (real)"))
+    process.exit(0)
+  }
+  console.warn(gray("○ Installed font is the Inter fallback from an earlier run"))
 }
 
 console.warn(`${yellow("⚠")} Optional dependency @digitalgroundgame/fonts is not installed.`)
@@ -50,6 +63,22 @@ if (!process.env.GH_FONT_READ) {
   were skipped. Run 'pnpm reinstall' to force a fresh install and verify the token.`,
     ),
   )
+}
+
+// A deploy that degrades to Inter ships the wrong typeface with a green build — the
+// exact failure mode that put the fallback on a preview deployment unnoticed. Stop here
+// so the build fails at install time instead of at somebody's eyeballs.
+if (fontsRequired) {
+  console.error(`${red("✖")} FONTS_REQUIRED is set — refusing to fall back to Inter.`)
+  console.error(
+    gray(
+      `  This build must ship FKScreamer. Check GH_FONT_READ: a GitHub PAT with
+  read:packages scope that has not expired, exposed to the build (not just runtime).
+  Note the pnpm store is cached, so rebuild WITHOUT cache after rotating the token,
+  or the store will still be missing @digitalgroundgame/fonts.`,
+    ),
+  )
+  process.exit(1)
 }
 
 cpSync(fallbackFont, fontPath)

--- a/tests/scripts/install-fonts.test.ts
+++ b/tests/scripts/install-fonts.test.ts
@@ -135,6 +135,67 @@ describe("install-fonts.ts", () => {
     })
   })
 
+  describe("when FONTS_REQUIRED is set (deploy builds)", () => {
+    it("fails instead of silently shipping the Inter fallback", () => {
+      const result = runScript(tmpRoot, { FONTS_REQUIRED: "true", GH_FONT_READ: "expired-token" })
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain("refusing to fall back to Inter")
+      expect(existsSync(FONT_FILE)).toBe(false)
+    })
+
+    it("still reports why the package was missing before failing", () => {
+      const result = runScript(tmpRoot, { FONTS_REQUIRED: "true", GH_FONT_READ: "expired-token" })
+      expect(result.stderr).toContain("GH_FONT_READ is set, but the package was not found")
+    })
+
+    it("points at the build cache, the non-obvious half of the fix", () => {
+      const result = runScript(tmpRoot, { FONTS_REQUIRED: "true" })
+      expect(result.stderr).toContain("rebuild WITHOUT cache")
+    })
+
+    it("succeeds when the real fonts are present", () => {
+      mkdirSync(PRIVATE_FONTS_SRC, { recursive: true })
+      writeFileSync(resolve(PRIVATE_FONTS_SRC, "FKScreamer-Bold.woff2"), "fake-font-data")
+      const result = runScript(tmpRoot, { FONTS_REQUIRED: "true" })
+      expect(result.status).toBe(0)
+    })
+
+    it("rejects a stale Inter fallback left by an earlier run", () => {
+      writeFileSync(FONT_FILE, INTER_BOLD)
+      const result = runScript(tmpRoot, { FONTS_REQUIRED: "true" })
+      expect(result.status).toBe(1)
+    })
+
+    it("is off by default, keeping local installs and fork CI lenient", () => {
+      const result = runScript(tmpRoot)
+      expect(result.status).toBe(0)
+      expect(result.stderr).toContain("Copied Inter Bold as fallback font")
+    })
+  })
+
+  describe("when a stale Inter fallback is already installed", () => {
+    beforeEach(() => {
+      writeFileSync(FONT_FILE, INTER_BOLD)
+    })
+
+    it("does not mistake it for the real font", () => {
+      const result = runScript(tmpRoot)
+      expect(result.stderr).not.toContain("already installed (real)")
+      expect(result.stderr).toContain("Inter fallback from an earlier run")
+    })
+
+    it("still exits 0 outside a deploy build", () => {
+      expect(runScript(tmpRoot).status).toBe(0)
+    })
+
+    it("is replaced once the real font becomes available", () => {
+      mkdirSync(PRIVATE_FONTS_SRC, { recursive: true })
+      writeFileSync(resolve(PRIVATE_FONTS_SRC, "FKScreamer-Bold.woff2"), "fake-font-data")
+      runScript(tmpRoot)
+      expect(readFileSync(FONT_FILE, "utf8")).toBe("fake-font-data")
+    })
+  })
+
   describe("when a stale small placeholder exists (< 1000 bytes)", () => {
     beforeEach(() => {
       writeFileSync(FONT_FILE, Buffer.alloc(100, 0x00))


### PR DESCRIPTION
## Problem

`@digitalgroundgame/fonts` is an `optionalDependency`, so when `GH_FONT_READ` expires or isn't exposed to the build, pnpm skips it, `install-fonts.ts` copies the bundled Inter as a fallback, and the build **exits 0**. The site renders the wrong typeface behind a fully green build.

That's how the expired token reached a preview deployment unnoticed — `https://pr-906.pragmaticpapers.com/fonts/FKScreamer-Bold.woff2` served 24356 bytes (byte-identical to `scripts/Inter-Bold.woff2`) while production served the real 36652-byte FKScreamer. No check caught it; it was spotted by eye.

## Approach

The fallback exists so contributors and fork CI — which legitimately have no access to the private package — can still `pnpm install`. That stays. Deploy builds opt in to strictness instead.

- **`FONTS_REQUIRED=true` makes any fallback fatal.** Set in the Dockerfile *builder stage*, so it covers Coolify (prod + preview) while local installs and fork CI keep the lenient path. Verified the Dockerfile is deploy-only: `docker-compose.yml` runs Postgres alone, `docker-compose.e2e.yml` doesn't build the image, and the builder stage has exactly one `pnpm install`.
- **Same flag on `update-snapshots.yml`**, where a fallback would bake the wrong typeface into committed visual baselines. Set at job level so it reaches the install step inside the `setup-project` composite action.
- **The "already installed (real)" check was size-only**, and the 24KB fallback clears the 1000-byte bar — so a stale Inter reported itself as real and skipped the guard entirely. It now compares bytes against the known fallback.
- **The error names the cache**, which is the non-obvious half of the fix: the pnpm store is a `--mount=type=cache` keyed on the lockfile, so rotating the token without a no-cache rebuild reuses a store that's still missing the package.

Also corrects a comment claiming the fallback is ~74KB when it's 24356 bytes — harmless to the `> 1000` guard, but misleading to anyone reasoning about that threshold.

## What it looks like

```
⚠ Optional dependency @digitalgroundgame/fonts is not installed.
  Reason: GH_FONT_READ is set, but the package was not found.
  ...
✖ FONTS_REQUIRED is set — refusing to fall back to Inter.
  This build must ship FKScreamer. Check GH_FONT_READ: a GitHub PAT with
  read:packages scope that has not expired, exposed to the build (not just runtime).
  Note the pnpm store is cached, so rebuild WITHOUT cache after rotating the token,
  or the store will still be missing @digitalgroundgame/fonts.
```

The existing diagnostic still prints first, so the log says *why* before it says *what to do*.

## Testing

- `tests/scripts/install-fonts.test.ts`: 23 pass, up from 13. New cases cover the guard firing on an expired token, the stale-Inter bypass, the real-fonts success path, and that the flag is off by default so local/fork installs stay lenient.
- Full `tests/scripts` suite: 191 pass. `check-types`, `lint:ci`, `format` clean.
- Ran the script against a temp cwd to confirm the real exit code and message.
- `update-snapshots.yml` parsed to confirm the job-level env lands where intended.

## Note

This does **not** fix the expired token — that's a credential rotation in Coolify and the GitHub repo secret, plus a no-cache rebuild. It ensures the next expiry fails the build instead of shipping quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
