### PR TITLE
fix(scripts): title the dev → main PR "Release <version>"

### DIFF
--- a/scripts/hotfix.ts
+++ b/scripts/hotfix.ts
@@ -98,7 +98,7 @@ export async function main(): Promise<void> {
     prepareBranch(backmergeBranch(version), "main", tag)
     run(`git push origin ${backmergeBranch(version)}`)
 
-    const devPrUrl = createOrReusePr(backmergeBranch(version), "dev")
+    const devPrUrl = createOrReusePr(backmergeBranch(version), "dev", `Back-merge ${tag} into dev`)
     console.warn(`\n${green("✔")} Back-merge PR to dev: ${devPrUrl}`)
 
     await autoMergeAndWait(devPrUrl)

--- a/scripts/release-lib.ts
+++ b/scripts/release-lib.ts
@@ -147,14 +147,21 @@ export function commitIfStaged(message: string): void {
   run(`git commit -m "${message}"`)
 }
 
-/** Open PR URL for `branch` → `base`, reusing one from an earlier run if present. */
-export function createOrReusePr(branch: string, base: string): string {
+/**
+ * Open PR URL for `branch` → `base`, reusing one from an earlier run if present.
+ *
+ * `--fill` takes the title from the commit subject only when the branch carries a
+ * single commit; with several it falls back to the head branch name, which is how the
+ * dev → main release PR ended up titled "dev". Pass `title` for any branch that can
+ * carry more than one commit — `--title` overrides `--fill` and still autofills the body.
+ */
+export function createOrReusePr(branch: string, base: string, title?: string): string {
   const existing = capture(prListCommand(branch, base))
   if (existing) {
     console.warn(`${yellow("!")} Reusing open PR for ${branch} → ${base}`)
     return existing
   }
-  return capture(`gh pr create -f -B ${base}`)
+  return capture(`gh pr create -f ${title ? `-t "${title}" ` : ""}-B ${base}`)
 }
 
 export function ask(question: string): Promise<string> {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -96,7 +96,7 @@ export async function main(): Promise<void> {
     run(`git checkout dev`)
     run(`git pull origin dev`)
 
-    const mainPrUrl = createOrReusePr("dev", "main")
+    const mainPrUrl = createOrReusePr("dev", "main", `Release ${version}`)
     console.warn(`\n${green("✔")} PR to main: ${mainPrUrl}`)
 
     await autoMergeAndWait(mainPrUrl)

--- a/tests/scripts/hotfix.test.ts
+++ b/tests/scripts/hotfix.test.ts
@@ -81,7 +81,11 @@ describe("hotfix main()", () => {
     expect(lib.waitForMerge).toHaveBeenCalledOnce()
     // phase 2
     expect(lib.prepareBranch).toHaveBeenCalledWith("chore/back-merge-v1.0.1", "main", "v1.0.1")
-    expect(lib.createOrReusePr).toHaveBeenCalledWith("chore/back-merge-v1.0.1", "dev")
+    expect(lib.createOrReusePr).toHaveBeenCalledWith(
+      "chore/back-merge-v1.0.1",
+      "dev",
+      "Back-merge v1.0.1 into dev",
+    )
     expect(lib.autoMergeAndWait).toHaveBeenCalledOnce()
   })
 
@@ -95,7 +99,11 @@ describe("hotfix main()", () => {
       "main",
       "v1.0.1",
     )
-    expect(lib.createOrReusePr).toHaveBeenCalledExactlyOnceWith("chore/back-merge-v1.0.1", "dev")
+    expect(lib.createOrReusePr).toHaveBeenCalledExactlyOnceWith(
+      "chore/back-merge-v1.0.1",
+      "dev",
+      "Back-merge v1.0.1 into dev",
+    )
     expect(lib.autoMergeAndWait).toHaveBeenCalledOnce()
     expect(lib.waitForMerge).not.toHaveBeenCalled()
   })

--- a/tests/scripts/release-lib.test.ts
+++ b/tests/scripts/release-lib.test.ts
@@ -258,6 +258,18 @@ describe("side-effecting helpers", () => {
     expect(execSync).toHaveBeenNthCalledWith(2, "gh pr create -f -B dev", expect.any(Object))
   })
 
+  it("createOrReusePr sets an explicit title, since --fill would use the branch name", () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce("" as never) // no existing PR
+      .mockReturnValueOnce("https://github.com/o/r/pull/11\n" as never)
+    createOrReusePr("dev", "main", "Release 1.2.3")
+    expect(execSync).toHaveBeenNthCalledWith(
+      2,
+      'gh pr create -f -t "Release 1.2.3" -B main',
+      expect.any(Object),
+    )
+  })
+
   it("autoMergeAndWait falls back to a manual prompt when auto-merge can't be enabled", async () => {
     stubPrompt("")
     vi.mocked(execSync)

--- a/tests/scripts/release.test.ts
+++ b/tests/scripts/release.test.ts
@@ -66,8 +66,8 @@ describe("release main()", () => {
     expect(lib.commitIfStaged).toHaveBeenCalledWith("Bump package.json to v1.0.0")
     expect(lib.createOrReusePr).toHaveBeenCalledWith("chore/v1.0.0", "dev")
     expect(lib.waitForMerge).toHaveBeenCalledOnce()
-    // phase 2
-    expect(lib.createOrReusePr).toHaveBeenCalledWith("dev", "main")
+    // phase 2 — titled "Release <version>", not the "dev" that --fill would derive
+    expect(lib.createOrReusePr).toHaveBeenCalledWith("dev", "main", "Release 1.0.0")
     expect(lib.autoMergeAndWait).toHaveBeenCalledOnce()
     // phase 3 is not chained (release.yml tags automatically)
     expect(c.some((cmd) => cmd.startsWith("git tag"))).toBe(false)
@@ -79,7 +79,7 @@ describe("release main()", () => {
 
     expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled()
     expect(lib.prepareBranch).not.toHaveBeenCalled()
-    expect(lib.createOrReusePr).toHaveBeenCalledExactlyOnceWith("dev", "main")
+    expect(lib.createOrReusePr).toHaveBeenCalledExactlyOnceWith("dev", "main", "Release 1.0.0")
     expect(lib.autoMergeAndWait).toHaveBeenCalledOnce()
     expect(lib.waitForMerge).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Problem

`gh pr create --fill` takes the title from the commit subject only when the branch carries a **single** commit. With several, it falls back to the head branch name.

Phase 1's branch has exactly one commit (the version bump), so it titles correctly — `Bump package.json to v2.5.1 (#908)`. But phase 2's PR is `dev → main`, which collects every commit since the last release, so it came out titled **`dev`**.

That's not hypothetical: PR **#877** is merged with the literal title `dev`. #887 and #909 read correctly only because they were renamed by hand.

## Fix

Pass an explicit title. Per `gh pr create --help`:

> if the `--title` and/or `--body` are also provided alongside `--fill`, the values specified by `--title` and/or `--body` will take precedence and overwrite any autofilled content

So `-f -t "Release 2.5.1"` keeps the autofilled body and fixes only the title.

`hotfix.ts`'s back-merge PR has the same problem for the same reason — its branch carries all of main's commits not yet in dev — and gets `Back-merge <tag> into dev`. Phase 1 in both scripts is left on plain `--fill`, since a single-commit branch already titles correctly.

## Testing

- `tests/scripts`: 192 pass. New case asserts the exact command (`gh pr create -f -t "Release 1.2.3" -B main`); the release and hotfix orchestration tests now pin the titles.
- `check-types`, `lint:ci`, `format` clean.
- Verified the `--title`/`--fill` precedence against the installed gh (2.45.0) rather than assuming it.

## Note

Builds on the `createOrReusePr` helper from #906, so it's branched off `dev` after that merged. No effect on the in-flight 2.5.1 release — #909 is already titled correctly; this stops the next release needing a manual rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
