### PR TITLE
fix(scripts): drop auto-merge from the dev↔main sync PRs

### DIFF
--- a/scripts/hotfix.ts
+++ b/scripts/hotfix.ts
@@ -15,7 +15,6 @@ import { fileURLToPath } from "node:url"
 
 import { blue, gray, green, red } from "./ansi.mjs"
 import {
-  autoMergeAndWait,
   bumpMessage,
   commitIfStaged,
   createOrReusePr,
@@ -24,6 +23,7 @@ import {
   requireGh,
   run,
   waitForMerge,
+  waitForSyncMerge,
 } from "./release-lib"
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..")
@@ -101,7 +101,7 @@ export async function main(): Promise<void> {
     const devPrUrl = createOrReusePr(backmergeBranch(version), "dev", `Back-merge ${tag} into dev`)
     console.warn(`\n${green("✔")} Back-merge PR to dev: ${devPrUrl}`)
 
-    await autoMergeAndWait(devPrUrl)
+    await waitForSyncMerge(devPrUrl)
   }
 }
 

--- a/scripts/release-lib.ts
+++ b/scripts/release-lib.ts
@@ -56,15 +56,6 @@ export function prStateCommand(ref: PrRef): string {
   return `gh api repos/${ref.owner}/${ref.repo}/pulls/${ref.number} --jq '${PR_STATE_JQ}'`
 }
 
-/**
- * Queue an auto-merge that lands as a real **merge commit** (`--merge`), never a
- * squash, and waits for required checks (`--auto`). This is what keeps the sync
- * branches (dev↔main) from diverging.
- */
-export function autoMergeCommand(prUrl: string): string {
-  return `gh pr merge "${prUrl}" --auto --merge`
-}
-
 // ── Side-effecting helpers ─────────────────────────────────────────────────
 
 export function run(cmd: string): void {
@@ -174,10 +165,6 @@ export function ask(question: string): Promise<string> {
   })
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 export function prState(prUrl: string): string {
   return capture(prStateCommand(parsePrRef(prUrl)))
 }
@@ -196,33 +183,18 @@ export async function waitForMerge(prUrl: string): Promise<void> {
 }
 
 /**
- * Enable a merge-commit auto-merge and poll until it lands. Removes the manual
- * "remember to pick merge, not squash, and don't click Update branch" footgun on
- * the dev↔main sync PRs. Falls back to a manual merge prompt if auto-merge can't
- * be enabled (e.g. the repo doesn't have it turned on).
+ * Wait on a dev↔main sync PR, which has to be merged by hand: these PRs are merged
+ * with a ruleset bypass, and `gh pr merge --auto` cannot bypass a ruleset — it either
+ * refuses outright or queues a merge that never fires, leaving the release polling
+ * forever. So prompt instead, and lead with the part that actually matters.
+ *
+ * The merge MUST be a merge commit. A squash rewrites the commits onto the target and
+ * leaves dev and main permanently diverged, which is the whole reason these PRs exist.
  */
-export async function autoMergeAndWait(prUrl: string, pollMs = 10_000): Promise<void> {
-  try {
-    run(autoMergeCommand(prUrl))
-    console.warn(`${green("✔")} Auto-merge (merge commit) enabled — waiting for checks…`)
-  } catch {
-    console.warn(
-      `${yellow("!")} Could not enable auto-merge. Merge it manually with a ` +
-        `${yellow("merge commit")} (not squash), and do not click "Update branch".`,
-    )
-    return waitForMerge(prUrl)
-  }
-
-  for (;;) {
-    const state = prState(prUrl)
-    if (state === "MERGED") {
-      console.warn(`${green("✔")} PR merged`)
-      return
-    }
-    if (state === "CLOSED") {
-      console.error(`${red("✖")} PR was closed without merging`)
-      process.exit(1)
-    }
-    await sleep(pollMs)
-  }
+export async function waitForSyncMerge(prUrl: string): Promise<void> {
+  console.warn(
+    `${yellow("!")} Merge this one with a ${yellow("merge commit")} — not a squash, ` +
+      `and do not click "Update branch". A squash diverges dev from main.`,
+  )
+  return waitForMerge(prUrl)
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -2,7 +2,8 @@
 //   1) branch off dev, bump package.json, open PR → dev   (CI runs)
 //   2) open PR dev → main and land it as a MERGE COMMIT    (keeps branches in sync)
 //   3) tag main and create the GitHub release
-// Phase 2's merge is auto-enabled as a merge commit so dev and main never diverge.
+// Phase 2 must be merged by hand as a merge commit so dev and main never diverge:
+// these PRs need a ruleset bypass, which `gh pr merge --auto` cannot perform.
 // --phase is a STARTING point and the run chains forward: the default `--phase 1`
 // carries through phase 2 once you confirm the dev PR merged. Phase 3 is separate —
 // release.yml tags automatically on the version bump, so chaining into it would race
@@ -17,7 +18,6 @@ import { fileURLToPath } from "node:url"
 
 import { blue, gray, green, red } from "./ansi.mjs"
 import {
-  autoMergeAndWait,
   bumpMessage,
   capture,
   commitIfStaged,
@@ -27,6 +27,7 @@ import {
   requireGh,
   run,
   waitForMerge,
+  waitForSyncMerge,
 } from "./release-lib"
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..")
@@ -99,7 +100,7 @@ export async function main(): Promise<void> {
     const mainPrUrl = createOrReusePr("dev", "main", `Release ${version}`)
     console.warn(`\n${green("✔")} PR to main: ${mainPrUrl}`)
 
-    await autoMergeAndWait(mainPrUrl)
+    await waitForSyncMerge(mainPrUrl)
   }
 
   // ── Phase 3: Tag and release ─────────────────────────────────────────────

--- a/tests/scripts/hotfix.test.ts
+++ b/tests/scripts/hotfix.test.ts
@@ -7,7 +7,7 @@ const lib = vi.hoisted(() => ({
   capture: vi.fn(() => "https://github.com/o/r/pull/1"),
   requireGh: vi.fn(),
   waitForMerge: vi.fn(),
-  autoMergeAndWait: vi.fn(),
+  waitForSyncMerge: vi.fn(),
   prepareBranch: vi.fn(),
   commitIfStaged: vi.fn(),
   createOrReusePr: vi.fn(() => "https://github.com/o/r/pull/1"),
@@ -86,7 +86,7 @@ describe("hotfix main()", () => {
       "dev",
       "Back-merge v1.0.1 into dev",
     )
-    expect(lib.autoMergeAndWait).toHaveBeenCalledOnce()
+    expect(lib.waitForSyncMerge).toHaveBeenCalledOnce()
   })
 
   it("runs only the back-merge for --phase 2", async () => {
@@ -104,7 +104,7 @@ describe("hotfix main()", () => {
       "dev",
       "Back-merge v1.0.1 into dev",
     )
-    expect(lib.autoMergeAndWait).toHaveBeenCalledOnce()
+    expect(lib.waitForSyncMerge).toHaveBeenCalledOnce()
     expect(lib.waitForMerge).not.toHaveBeenCalled()
   })
 

--- a/tests/scripts/release-lib.test.ts
+++ b/tests/scripts/release-lib.test.ts
@@ -7,8 +7,6 @@ import {
   PR_STATE_JQ,
   VERSION_RE,
   ask,
-  autoMergeAndWait,
-  autoMergeCommand,
   branchExists,
   bumpMessage,
   capture,
@@ -25,6 +23,7 @@ import {
   requireGh,
   run,
   waitForMerge,
+  waitForSyncMerge,
 } from "../../scripts/release-lib"
 
 vi.mock("node:child_process", () => ({ execSync: vi.fn() }))
@@ -83,12 +82,6 @@ describe("command builders", () => {
   it("prStateCommand queries the PR and collapses state via jq", () => {
     expect(prStateCommand(ref)).toBe(`gh api repos/o/r/pulls/7 --jq '${PR_STATE_JQ}'`)
     expect(PR_STATE_JQ).toContain("MERGED")
-  })
-
-  it("autoMergeCommand forces a merge commit, never a squash", () => {
-    const cmd = autoMergeCommand("https://github.com/o/r/pull/7")
-    expect(cmd).toBe(`gh pr merge "https://github.com/o/r/pull/7" --auto --merge`)
-    expect(cmd).not.toContain("--squash")
   })
 
   it("bumpMessage matches the commit subject the release makes", () => {
@@ -170,25 +163,34 @@ describe("side-effecting helpers", () => {
     expect(execSync).toHaveBeenCalledTimes(2)
   })
 
-  it("autoMergeAndWait enables auto-merge then polls to MERGED", async () => {
-    vi.mocked(execSync)
-      .mockReturnValueOnce("" as never) // run(autoMergeCommand)
-      .mockReturnValueOnce("OPEN\n" as never) // poll 1
-      .mockReturnValueOnce("MERGED\n" as never) // poll 2
-    await autoMergeAndWait(PR, 1)
-    expect(execSync).toHaveBeenNthCalledWith(1, autoMergeCommand(PR), expect.any(Object))
-    expect(execSync).toHaveBeenCalledTimes(3)
+  it("waitForSyncMerge never issues a merge command — the operator merges by hand", async () => {
+    stubPrompt("")
+    vi.mocked(execSync).mockReturnValue("MERGED\n" as never)
+    await waitForSyncMerge(PR)
+
+    const commands = vi.mocked(execSync).mock.calls.map((c) => c[0] as string)
+    expect(commands.some((cmd) => cmd.includes("gh pr merge"))).toBe(false)
+    expect(readline.createInterface).toHaveBeenCalled()
   })
 
-  it("autoMergeAndWait exits if the PR is closed without merging", async () => {
+  it("waitForSyncMerge warns against squashing, which would diverge dev from main", async () => {
+    stubPrompt("")
+    vi.mocked(execSync).mockReturnValue("MERGED\n" as never)
+    const warn = vi.spyOn(console, "warn")
+    await waitForSyncMerge(PR)
+
+    const output = warn.mock.calls.flat().join(" ")
+    expect(output).toContain("merge commit")
+    expect(output).toContain("not a squash")
+  })
+
+  it("waitForSyncMerge keeps prompting until the PR actually reports MERGED", async () => {
+    stubPrompt("")
     vi.mocked(execSync)
-      .mockReturnValueOnce("" as never) // run(autoMergeCommand)
-      .mockReturnValueOnce("CLOSED\n" as never) // poll
-    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`exit:${code}`)
-    }) as never)
-    await expect(autoMergeAndWait(PR, 1)).rejects.toThrow("exit:1")
-    exit.mockRestore()
+      .mockReturnValueOnce("OPEN\n" as never)
+      .mockReturnValueOnce("MERGED\n" as never)
+    await waitForSyncMerge(PR)
+    expect(vi.mocked(readline.createInterface)).toHaveBeenCalledTimes(2)
   })
 
   it("branchExists reports on the local ref, not a remote one", () => {
@@ -268,17 +270,6 @@ describe("side-effecting helpers", () => {
       'gh pr create -f -t "Release 1.2.3" -B main',
       expect.any(Object),
     )
-  })
-
-  it("autoMergeAndWait falls back to a manual prompt when auto-merge can't be enabled", async () => {
-    stubPrompt("")
-    vi.mocked(execSync)
-      .mockImplementationOnce(() => {
-        throw new Error("auto-merge not allowed")
-      }) // run(autoMergeCommand) fails
-      .mockReturnValueOnce("MERGED\n" as never) // waitForMerge → prState
-    await autoMergeAndWait(PR, 1)
-    expect(readline.createInterface).toHaveBeenCalled()
   })
 })
 

--- a/tests/scripts/release.test.ts
+++ b/tests/scripts/release.test.ts
@@ -9,7 +9,7 @@ const lib = vi.hoisted(() => ({
   capture: vi.fn(() => "https://github.com/o/r/pull/1"),
   requireGh: vi.fn(),
   waitForMerge: vi.fn(),
-  autoMergeAndWait: vi.fn(),
+  waitForSyncMerge: vi.fn(),
   prepareBranch: vi.fn(),
   commitIfStaged: vi.fn(),
   createOrReusePr: vi.fn(() => "https://github.com/o/r/pull/1"),
@@ -68,7 +68,7 @@ describe("release main()", () => {
     expect(lib.waitForMerge).toHaveBeenCalledOnce()
     // phase 2 — titled "Release <version>", not the "dev" that --fill would derive
     expect(lib.createOrReusePr).toHaveBeenCalledWith("dev", "main", "Release 1.0.0")
-    expect(lib.autoMergeAndWait).toHaveBeenCalledOnce()
+    expect(lib.waitForSyncMerge).toHaveBeenCalledOnce()
     // phase 3 is not chained (release.yml tags automatically)
     expect(c.some((cmd) => cmd.startsWith("git tag"))).toBe(false)
   })
@@ -80,7 +80,7 @@ describe("release main()", () => {
     expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled()
     expect(lib.prepareBranch).not.toHaveBeenCalled()
     expect(lib.createOrReusePr).toHaveBeenCalledExactlyOnceWith("dev", "main", "Release 1.0.0")
-    expect(lib.autoMergeAndWait).toHaveBeenCalledOnce()
+    expect(lib.waitForSyncMerge).toHaveBeenCalledOnce()
     expect(lib.waitForMerge).not.toHaveBeenCalled()
   })
 
@@ -92,7 +92,7 @@ describe("release main()", () => {
     expect(c).toContain('git tag v1.0.0 -m "v1.0.0" -s')
     expect(lib.capture).toHaveBeenCalledWith('gh release create v1.0.0 --target main -t "v1.0.0"')
     expect(lib.waitForMerge).not.toHaveBeenCalled()
-    expect(lib.autoMergeAndWait).not.toHaveBeenCalled()
+    expect(lib.waitForSyncMerge).not.toHaveBeenCalled()
     expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Problem

`autoMergeAndWait` ran `gh pr merge --auto --merge` on the dev → main release PR and the main → dev back-merge PR. Those PRs land via a **ruleset bypass**, and auto-merge has no way to perform one. So it either:

- refuses outright — the `catch` falls through to the manual prompt, meaning the auto-merge attempt was dead weight, or
- queues a merge that never fires, leaving the release polling every 10s for a PR only a human can land

Either way the operator merges by hand. The automation just added a failure mode.

## Change

`autoMergeAndWait` → `waitForSyncMerge`: prompt, then confirm the PR actually reports `MERGED` before the release continues. Identical confirmation loop, minus the merge attempt that couldn't succeed.

The **"merge commit, not squash"** instruction used to appear only in the auto-merge *failure* path, so on a successful queue it was never shown. It's now stated up front on every sync PR — a squash rewrites the commits onto the target and leaves dev and main permanently diverged, which is the entire reason these PRs exist.

Removes `autoMergeCommand`, `autoMergeAndWait`, and the now-unused `sleep`. `waitForMerge`, `prState`, and `prStateCommand` are unchanged and still used by both scripts.

## Testing

- `tests/scripts`: 190 pass. New cases assert no `gh pr merge` command is ever issued, that the anti-squash warning is printed, and that the prompt repeats until the PR reports `MERGED`.
- `check-types`, `lint:ci`, `format` clean. No stray `autoMerge` references remain in `scripts/` or `tests/`.

## Note

Independent of #910 (PR titles) — both touch `release-lib.ts` but in different functions. Whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
