### PR TITLE
fix(users): hide the merged email field from the admin form

### DIFF
--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -31,10 +31,24 @@ export const Users: CollectionConfig = {
   auth: true,
   fields: [
     {
+      // Payload's auth already supplies an `email` field and merges this
+      // declaration into it; we redeclare it only to attach field-level read
+      // access. The auth form (login, first-user registration, the Auth panel
+      // on a user doc) renders its own email input, and Payload normally keeps
+      // the merged field from rendering a second one via a `Field: false`
+      // component. That suppression is delivered through form state, which
+      // skips any field whose `access.read` denies — so on the first-user
+      // registration form (no user yet, so `selfOrAdminFieldLevel` is false)
+      // the client fell back to the default email input and drew a second
+      // "Email" box. `admin.hidden` suppresses it on the client instead, which
+      // holds whether or not read access passes. List columns are unaffected.
       name: "email",
       type: "email",
       access: {
         read: selfOrAdminFieldLevel,
+      },
+      admin: {
+        hidden: true,
       },
     },
     {


### PR DESCRIPTION
## Problem

The first-user registration form renders **two** "Email" inputs.

`Users` redeclares the `email` field only to attach field-level read access (added in #889). Payload's auth already supplies `email` and merges our declaration into it — and it normally stops the merged copy from rendering a second input by handing the client a `Field: false` component.

That suppression travels through **form state**, which skips any field whose `access.read` denies. On the registration form there is no user yet, so `selfOrAdminFieldLevel` returns `false`, the `Field: false` marker never reaches the client, and it falls back to the default email input — drawing a second box next to the auth form's own.

## Fix

Suppress the merged field with `admin.hidden` instead. That is applied client-side and holds whether or not read access passes. List columns are unaffected, and the field-level read access is unchanged.

## Testing

- `pnpm check-types`, `pnpm lint:ci` — clean
- `pnpm test:unit` — 719 passed

Split out of #742, where it was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)