### PR TITLE
fix(ci): stop E2E from booting Payload with an empty secret

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -39,7 +39,7 @@ runs:
       run: |
         cat > .env << EOF
         DATABASE_URI=postgres://postgres:postgres@localhost:5432/pragmatic-papers
-        PAYLOAD_SECRET=${{ inputs.payload-secret }}
+        PAYLOAD_SECRET=${{ inputs.payload-secret || 'ci-setup-project-secret' }}
         NEXT_PUBLIC_SERVER_URL=http://localhost:8000
         USE_LOCAL_STORAGE=true
         EOF

--- a/.github/workflows/playwright-pin-check.yml
+++ b/.github/workflows/playwright-pin-check.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           node-version: "24.x"
           gh-font-read-token: ${{ secrets.GH_FONT_READ }}
-          payload-secret: ${{ secrets.PAYLOAD_SECRET }}
 
       - name: Check Playwright Docker image pin
         run: pnpm exec tsx scripts/check-playwright-image-pin.ts

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+  PAYLOAD_SECRET: e2e-payload-secret
   NEXT_PUBLIC_SERVER_URL: http://localhost:8000
   USE_LOCAL_STORAGE: "true"
   # The Merch block has no built-in store site — without this it renders
@@ -122,7 +122,7 @@ jobs:
         with:
           node-version: "24.x"
           gh-font-read-token: ${{ secrets.GH_FONT_READ }}
-          payload-secret: ${{ secrets.PAYLOAD_SECRET }}
+          payload-secret: ${{ env.PAYLOAD_SECRET }}
 
       # Restores Next.js incremental compilation cache so `next build` inside
       # the E2E run only recompiles what changed since the last run on this

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -35,7 +35,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+  PAYLOAD_SECRET: e2e-payload-secret
   NEXT_PUBLIC_SERVER_URL: http://localhost:8000
   USE_LOCAL_STORAGE: "true"
   # Keep in step with playwright.yml: the Merch block has no built-in store
@@ -139,7 +139,7 @@ jobs:
         with:
           node-version: "24.x"
           gh-font-read-token: ${{ secrets.GH_FONT_READ }}
-          payload-secret: ${{ secrets.PAYLOAD_SECRET }}
+          payload-secret: ${{ env.PAYLOAD_SECRET }}
 
       - name: Cache Next.js build cache
         uses: actions/cache@v6

--- a/scripts/check-pending-migrations.mjs
+++ b/scripts/check-pending-migrations.mjs
@@ -2,8 +2,8 @@ import { PostgreSqlContainer } from "@testcontainers/postgresql"
 import { execSync } from "node:child_process"
 import { blue, green, red } from "./ansi.mjs"
 
-process.env.PAYLOAD_SECRET ??= "test-secret"
-process.env.USE_LOCAL_STORAGE ??= "true"
+process.env.PAYLOAD_SECRET ||= "test-secret"
+process.env.USE_LOCAL_STORAGE ||= "true"
 
 let container = null
 

--- a/scripts/test-e2e.mjs
+++ b/scripts/test-e2e.mjs
@@ -17,7 +17,7 @@ function isPortInUse(port) {
   })
 }
 
-process.env.PAYLOAD_SECRET ??= "test-secret-for-e2e-tests"
+process.env.PAYLOAD_SECRET ||= "test-secret-for-e2e-tests"
 
 let container = null
 
@@ -31,10 +31,10 @@ if (process.env.DATABASE_URI) {
   process.env.DATABASE_URI = container.getConnectionUri()
   console.warn(`${green("✔")} Test database started at ${process.env.DATABASE_URI}`)
 }
-process.env.USE_LOCAL_STORAGE ??= "true"
-process.env.PORT ??= "8000"
-process.env.NEXT_PUBLIC_SERVER_URL ??= `http://localhost:${process.env.PORT}`
-process.env.PAYLOAD_CONFIG_PATH ??= "src/payload.config.ts"
+process.env.USE_LOCAL_STORAGE ||= "true"
+process.env.PORT ||= "8000"
+process.env.NEXT_PUBLIC_SERVER_URL ||= `http://localhost:${process.env.PORT}`
+process.env.PAYLOAD_CONFIG_PATH ||= "src/payload.config.ts"
 process.env.E2E_MANAGED_SERVER = "true"
 
 const port = Number(process.env.PORT)

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -808,7 +808,7 @@ export interface MerchBlock {
    */
   autoplay?: boolean | null;
   /**
-   * Products are synced from Shopify hourly. Show the whole catalogue, or narrow it down below.
+   * Products are synced from Shopify automatically. Show the whole catalogue, or narrow it down below.
    */
   source?: ('all' | 'filtered') | null;
   /**
@@ -840,7 +840,7 @@ export interface MerchBlock {
   blockType: 'merch';
 }
 /**
- * Synced hourly from Shopify and stored as Shopify reports it — prices are raw amounts, not formatted strings, and the block decides how they read. Commerce fields are read-only; edit them in Shopify. The presentation fields at the bottom are ours and survive a sync.
+ * Synced from Shopify every few hours and stored as Shopify reports it — prices are raw amounts, not formatted strings, and the block decides how they read. Commerce fields are read-only; edit them in Shopify. The presentation fields at the bottom are ours and survive a sync.
  *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "merch".

--- a/tests/setup/integration-global-setup.ts
+++ b/tests/setup/integration-global-setup.ts
@@ -4,9 +4,9 @@ import { execSync } from "node:child_process"
 const TEMPLATE_DB = "pp_template"
 
 export async function setup(): Promise<() => Promise<void>> {
-  process.env.PAYLOAD_SECRET ??= "test-secret-for-integration-tests"
-  process.env.USE_LOCAL_STORAGE ??= "true"
-  process.env.NEXT_PUBLIC_SERVER_URL ??= "http://localhost:8000"
+  process.env.PAYLOAD_SECRET ||= "test-secret-for-integration-tests"
+  process.env.USE_LOCAL_STORAGE ||= "true"
+  process.env.NEXT_PUBLIC_SERVER_URL ||= "http://localhost:8000"
 
   let container = null
   let uri: string


### PR DESCRIPTION
## Context

Closes #919.

Every PR opened from a fork fails the *E2E tests* check during setup, before a test runs — first seen on #918:

```
● Running database migrations...
Error: Error: missing secret key. A secret key is needed to secure Payload.
```

GitHub withholds repository secrets from `pull_request` runs on forks, so `PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}` resolves to an **empty string** — present, not unset. `scripts/test-e2e.mjs` guarded it with `??=`, which only assigns on `null`/`undefined`, so the empty string survived and Payload refused to boot.

What changed:

- **`playwright.yml` / `update-snapshots.yml`** — use a literal E2E secret instead of `${{ secrets.PAYLOAD_SECRET }}`, matching what `ci.yml` already does. This is the load-bearing fix. Both jobs run against a throwaway database, so the real secret bought nothing and only made the workflows fork-hostile.
- **`test-e2e.mjs`, `check-pending-migrations.mjs`, `integration-global-setup.ts`** — `||=` instead of `??=`, so a present-but-empty value falls back too. `""` is the only falsy string, so this can't swallow a meaningful value like `"0"`. The latter two weren't reachable today (their jobs pass literals) but carried the same latent trap.
- **`setup-project`** — `||` fallback on the `.env` step so it never writes a bare `PAYLOAD_SECRET=`. The input default stays `""` on purpose: GitHub applies an input default only when the caller *omits* the input, not when it passes `""` ([actions/runner#2907](https://github.com/actions/runner/issues/2907)), which is exactly what fork runs produce.
- **`playwright-pin-check.yml`** — drop the `payload-secret` input; that job never boots Payload, it only parses files for pinned image tags.

Worth knowing: `.env` can never rescue this. Both `@next/env` and `dotenv` skip a `.env` key already present in `process.env`, and an empty string counts as present — so a job that sets `PAYLOAD_SECRET=""` must fix it at the job level, which is why the literal matters and the `.env` change alone would not have been enough.

### Second commit: regenerated `payload-types.ts`

Unrelated to the CI fix, folded in here rather than left on `dev`. #881 reworded two Merch admin descriptions ("synced from Shopify hourly" → "automatically", "Synced hourly" → "every few hours") without re-running `pnpm payload generate:types`, so the committed types kept the old copy in their doc comments. The commit is the tool's output against the current config, no hand edits — doc comments only, no type shape changes.

### For reviewer attention

1. `secrets.PAYLOAD_SECRET` is now referenced by **zero** workflows. If that value is the one production uses, it was previously handed to a job with `contents: write` that builds and runs whatever is on the branch — worth deciding whether to rotate it, and confirming nothing outside Actions reads it before removing it from repo settings.
2. This only unblocks E2E *setup*. Fork PRs still can't have baselines committed or comments posted (`GITHUB_TOKEN` is read-only on fork runs regardless of `permissions:`). Tracked as a follow-up in #919; happy to file it separately.

## Test Plan

Reproduced the exact CI failure locally and confirmed the fix clears it:

```bash
# Before — the failure, same `index.ts:843` frame as CI:
PAYLOAD_SECRET="" DATABASE_URI="postgres://…:5433/nope" pnpm payload migrate
# → Error: missing secret key.

# Still fails even with a good value in .env, proving .env can't rescue it:
printf 'PAYLOAD_SECRET=secret-from-dotenv-file\n' > .env && PAYLOAD_SECRET="" pnpm payload migrate
# → Error: missing secret key.

# After — via the wrapper, gets past the secret check and dies only on the
# deliberately unreachable database (index.ts:913 instead of :843):
PAYLOAD_SECRET="" DATABASE_URI="postgres://…:5433/nope" node scripts/test-e2e.mjs
# → Error: cannot connect to Postgres. connect ECONNREFUSED 127.0.0.1:5433
```

For the types commit: `pnpm payload generate:types` twice in a row is a no-op, and `pnpm check-types` passes.

Also green: `pnpm lint:ci`, `pnpm format`, `pnpm check-types`, `pnpm test:unit` (693 tests, 61 files). E2E not run locally per AGENTS.md — CI covers it.

To verify on a fork PR: this does **not** retroactively green #918. Its existing run replays the old workflow file, so it needs a fresh trigger (a new push to the fork branch, or "Update branch") rather than "Re-run jobs".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pQX58BGB67MsVFweY55K3