### PR TITLE
fix: dedupe footer global fetch to resolve N+1 query regression

### DIFF
--- a/src/Header/Component.tsx
+++ b/src/Header/Component.tsx
@@ -23,7 +23,7 @@ import React from "react"
 export async function Header(): Promise<React.JSX.Element> {
   const [{ navItems, actions }, { socials }]: [Header, Footer] = await Promise.all([
     getCachedGlobal("header", 1)(),
-    getCachedGlobal("footer", 1)(),
+    getCachedGlobal("footer", 2)(),
   ])
 
   return (

--- a/src/app/(frontend)/[slug]/page.tsx
+++ b/src/app/(frontend)/[slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function Page({ params, searchParams }: Args): Promise<Reac
   const pageNumber = pageString ? Math.max(Number(pageString) || 1, 1) : undefined
   const url = `/${slug}${pageNumber ? `?p=${pageNumber}` : ""}`
   let page: RequiredDataFromCollectionSlug<"pages"> | null = await queryPageBySlug(slug)
-  const { socials } = await getCachedGlobal("footer", 1)()
+  const { socials } = await getCachedGlobal("footer", 2)()
 
   // Remove this code once your website is seeded
   if (!page && slug === "home") {

--- a/src/utilities/__tests__/getGlobals.test.ts
+++ b/src/utilities/__tests__/getGlobals.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const findGlobal = vi.fn()
+
+vi.mock("payload", () => ({ getPayload: vi.fn(async () => ({ findGlobal })) }))
+vi.mock("@payload-config", () => ({ default: Promise.resolve({}) }))
+
+// `unstable_cache` needs an active Next.js request context to actually cache;
+// here we only care about the arguments it's called with (the cache key).
+const unstableCache = vi.fn(
+  (fn: () => Promise<unknown>, _keyParts?: string[], _options?: { tags?: string[] }) => fn,
+)
+vi.mock("next/cache", () => ({
+  unstable_cache: (...args: Parameters<typeof unstableCache>) => unstableCache(...args),
+}))
+
+const { getCachedGlobal } = await import("../getGlobals")
+
+describe("getCachedGlobal", () => {
+  beforeEach(() => {
+    findGlobal.mockReset()
+    unstableCache.mockClear()
+    findGlobal.mockImplementation(async ({ slug, depth }: { slug: string; depth: number }) => ({
+      slug,
+      depth,
+    }))
+  })
+
+  it("keys the cache by slug and depth so different depths don't collide", async () => {
+    await getCachedGlobal("footer", 1)()
+    await getCachedGlobal("footer", 2)()
+
+    const keyParts = unstableCache.mock.calls.map(([, keys]) => keys)
+    expect(keyParts).toEqual([
+      ["footer", "1"],
+      ["footer", "2"],
+    ])
+  })
+
+  it("forwards the requested depth to payload.findGlobal", async () => {
+    await getCachedGlobal("header", 3)()
+
+    expect(findGlobal).toHaveBeenCalledWith({ slug: "header", depth: 3 })
+  })
+
+  it("defaults depth to 0 when not provided", async () => {
+    await getCachedGlobal("footer")()
+
+    expect(findGlobal).toHaveBeenCalledWith({ slug: "footer", depth: 0 })
+    expect(unstableCache.mock.calls[0]?.[1]).toEqual(["footer", "0"])
+  })
+})

--- a/src/utilities/getGlobals.ts
+++ b/src/utilities/getGlobals.ts
@@ -3,10 +3,14 @@ import type { Config } from "src/payload-types"
 import configPromise from "@payload-config"
 import { unstable_cache } from "next/cache"
 import { getPayload } from "payload"
+import { cache } from "react"
 
 type Global = keyof Config["globals"]
 
-async function getGlobal<T extends Global>(slug: T, depth = 0): Promise<Config["globals"][T]> {
+const getGlobal = cache(async function getGlobalCached<T extends Global>(
+  slug: T,
+  depth = 0,
+): Promise<Config["globals"][T]> {
   const payload = await getPayload({ config: configPromise })
 
   const global = await payload.findGlobal({
@@ -15,13 +19,13 @@ async function getGlobal<T extends Global>(slug: T, depth = 0): Promise<Config["
   })
 
   return global as Config["globals"][T]
-}
+})
 
 /**
  * Returns a unstable_cache function mapped with the cache tag for the slug
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const getCachedGlobal = <T extends Global>(slug: T, depth = 0) =>
-  unstable_cache(async () => getGlobal(slug, depth), [slug], {
+  unstable_cache(async () => getGlobal(slug, depth), [slug, String(depth)], {
     tags: [`global_${slug}`],
   })


### PR DESCRIPTION
## Context

Fixes [PRAGMATIC-PAPERS-3](https://digital-ground-game.sentry.io/issues/7508515736/events/e2b7d7454b8b4f97985a2d63f5a07c15/) — an N+1 query alert on `GET /`, showing 6x repeated `pg-pool.connect` spans (20% of the transaction).

## Root cause

`Header`, `Footer`, and `[slug]/page.tsx` all fetch the `footer` global via `getCachedGlobal`, but two of the three call sites passed `depth: 1` while `Footer/Component.tsx` used `depth: 2`. The `unstable_cache` key only included `[slug]` (not depth), so the mismatched depths thrashed the cache and forced repeated `payload.findGlobal` → Postgres round trips per request.

## Fix

- Unified all `getCachedGlobal("footer", ...)` call sites to `depth: 2`
- Included `depth` in the `unstable_cache` key so different depths no longer collide
- Wrapped `getGlobal` in React's `cache()` for per-request de-dupe, so even a cold cache only hits Postgres once per request

## Test Plan

- Added `src/utilities/__tests__/getGlobals.test.ts`, covering the regression directly: asserts `unstable_cache` is keyed by both slug and depth, and that depth is correctly forwarded to `payload.findGlobal`
- CI: unit, integration, and E2E tests pass on this PR
- Verified `pr-926.pragmaticpapers.com` loads successfully
- Confirmed in Sentry that the fix commit's release shows no `db_query`/N+1 performance issue, unlike the prior release