### PR TITLE
fix: use text-foreground for byline separators

### DIFF
--- a/src/components/Authors/Byline.tsx
+++ b/src/components/Authors/Byline.tsx
@@ -60,7 +60,7 @@ export function Byline({ authors }: BylineProps): React.ReactNode {
         {authors.map(({ id, slug, name }, index) => (
           <React.Fragment key={id}>
             {index > 0 && (
-              <span className="text-primary">{getSeparator(index, authors.length)}</span>
+              <span className="text-foreground">{getSeparator(index, authors.length)}</span>
             )}
             <HoverPrefetchLink href={`/authors/${slug}`} className="hover:underline">
               {name}

--- a/src/heros/ArticleHero/__tests__/__snapshots__/ArticleHero.snapshot.test.tsx.snap
+++ b/src/heros/ArticleHero/__tests__/__snapshots__/ArticleHero.snapshot.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`ArticleHero > joins three authors with commas and a closing ampersand 1
           Alice Smith
         </a>
         <span
-          class="text-primary"
+          class="text-foreground"
         >
           , 
         </span>
@@ -88,7 +88,7 @@ exports[`ArticleHero > joins three authors with commas and a closing ampersand 1
           Bob Jones
         </a>
         <span
-          class="text-primary"
+          class="text-foreground"
         >
            & 
         </span>
@@ -307,7 +307,7 @@ exports[`ArticleHero > names every author, however many, with no remainder 1`] =
           Alice Smith
         </a>
         <span
-          class="text-primary"
+          class="text-foreground"
         >
           , 
         </span>
@@ -318,7 +318,7 @@ exports[`ArticleHero > names every author, however many, with no remainder 1`] =
           Bob Jones
         </a>
         <span
-          class="text-primary"
+          class="text-foreground"
         >
           , 
         </span>
@@ -329,7 +329,7 @@ exports[`ArticleHero > names every author, however many, with no remainder 1`] =
           Carol Diaz
         </a>
         <span
-          class="text-primary"
+          class="text-foreground"
         >
           , 
         </span>
@@ -340,7 +340,7 @@ exports[`ArticleHero > names every author, however many, with no remainder 1`] =
           Dan Reed
         </a>
         <span
-          class="text-primary"
+          class="text-foreground"
         >
           , 
         </span>
@@ -351,7 +351,7 @@ exports[`ArticleHero > names every author, however many, with no remainder 1`] =
           Erin Fox
         </a>
         <span
-          class="text-primary"
+          class="text-foreground"
         >
            & 
         </span>
@@ -792,7 +792,7 @@ exports[`ArticleHero > renders with populated authors 1`] = `
           Alice Smith
         </a>
         <span
-          class="text-primary"
+          class="text-foreground"
         >
            & 
         </span>


### PR DESCRIPTION
Closes #931

## Context

The separator spans between author names in the article byline were painted with `text-primary`, but `--primary` is the accent/button-fill token — its paired *text* token is `--primary-foreground`. Neutral body text should use `text-foreground`.

The separator is the one part of the byline that deliberately steps out of the brand color (the wrapper sets `text-brand` / `dark:text-brand-high-contrast`) to read as plain neutral text, so `text-foreground` is what it wants.

`text-primary` is close enough to neutral that the mistake is easy to miss, but the two tokens are distinct in both themes (`src/app/(frontend)/globals.css`):

| Token          | Light          | Dark           |
| -------------- | -------------- | -------------- |
| `--foreground` | `oklch(0.145)` | `oklch(0.985)` |
| `--primary`    | `oklch(0.205)` | `oklch(0.87)`  |

So separators rendered a shade washed out against the neutral text around them — lighter in light mode, dimmer in dark mode. And because `--primary` is meant as a *surface* color, a future rebrand that gave it a hue would tint the separators in a way nothing else in the byline follows.

Changes:

- `src/components/Authors/Byline.tsx` — `text-primary` → `text-foreground` on the separator span
- Updated the 3 `ArticleHero` snapshot baselines that captured the old class

## Test Plan

Automated:

- `pnpm test:unit` — 745 passed. The only diffs were the 3 expected `ArticleHero` snapshots, regenerated with `vitest run --project unit -u`
- `pnpm lint:ci` (`--max-warnings 0`), `pnpm check-types`, `pnpm format` — all clean

Manual:

1. Open an article with two or more authors, so the byline renders separators between names.
2. The separator glyphs (`, ` and ` & `) should now match the surrounding neutral body text exactly — check both light and dark mode.

Note: the byline sits inside `ArticleHero`, so if a visual baseline covers a multi-author byline, the Playwright screenshot job may need a baseline refresh. I skipped e2e locally per `AGENTS.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmSxoMNzM1kuqqsJA9vDP5)_