### PR TITLE
fix: rename footnote copy to sources

### DIFF
--- a/src/blocks/Footnote/Component.tsx
+++ b/src/blocks/Footnote/Component.tsx
@@ -16,7 +16,7 @@ export const FootnoteBlock: React.FC<FootnoteBlockProps> = ({ note, index, class
     <sup
       id={referenceId}
       className={cn(className, "not-prose px-0.5 font-mono -tracking-widest")}
-      title={`Footnote ${index}: ${note}`}
+      title={`Source ${index}: ${note}`}
     >
       <a
         className="text-brand dark:text-brand-high-contrast font-semibold underline-offset-6 hover:underline"

--- a/src/blocks/Footnote/FootnoteLabelClient.tsx
+++ b/src/blocks/Footnote/FootnoteLabelClient.tsx
@@ -19,7 +19,7 @@ export const FootnoteLabelClient: React.FC<FootnoteLabelClientProps> = ({ siblin
   const currentIndex =
     (note ? (footnotes.find((f) => f.note === note)?.index ?? null) : null) ?? index ?? null
 
-  if (!note) return <span>Footnote</span>
+  if (!note) return <span>Source</span>
   if (typeof currentIndex !== "number") return <span>{truncate(note, PREVIEW_LIMIT)}</span>
   if (sourceId) return <span>{`↗ [${currentIndex}]`}</span>
   return <span>{`[${currentIndex}]`}</span>

--- a/src/blocks/Footnote/FootnotesPreview.tsx
+++ b/src/blocks/Footnote/FootnotesPreview.tsx
@@ -14,7 +14,7 @@ export const FootnotesPreview: React.FC = () => {
   return (
     <div className="field-type">
       <div className="label-wrapper">
-        <p className="field-label">Footnotes</p>
+        <p className="field-label">Sources</p>
       </div>
       <ol
         style={{

--- a/src/blocks/Footnote/InsertExistingFootnote.tsx
+++ b/src/blocks/Footnote/InsertExistingFootnote.tsx
@@ -37,12 +37,12 @@ export const InsertExistingFootnote: React.FC = () => {
   return (
     <div className="field-type">
       <div className="label-wrapper">
-        <p className="field-label">Link to Existing Footnote</p>
+        <p className="field-label">Link to Existing Source</p>
       </div>
       <ReactSelect
         onChange={handleChange}
         options={options}
-        placeholder="— Select a footnote to link —"
+        placeholder="— Select a source to link —"
         value={selected}
       />
     </div>

--- a/src/blocks/Footnote/ReferenceNotice.tsx
+++ b/src/blocks/Footnote/ReferenceNotice.tsx
@@ -20,7 +20,7 @@ export const ReferenceNotice: React.FC = () => {
   return (
     <div className="field-type">
       <div className="label-wrapper">
-        <p className="field-label">Linked Footnote:</p>
+        <p className="field-label">Linked Source:</p>
       </div>
       <p
         style={{
@@ -35,7 +35,7 @@ export const ReferenceNotice: React.FC = () => {
         {attributionUrl && <span>{` | ${attributionUrl}`}</span>}
       </p>
       <p style={{ marginTop: "0.5rem", opacity: 0.5 }}>
-        To make changes, delete this footnote block and re-add it.
+        To make changes, delete this source block and re-add it.
       </p>
     </div>
   )

--- a/src/blocks/Footnote/config.ts
+++ b/src/blocks/Footnote/config.ts
@@ -10,7 +10,7 @@ export const FootnoteBlock: Block = {
       type: "text",
       admin: {
         hidden: true,
-        description: "The Optional ID of an existing footnote to link to. Hidden in the admin UI.",
+        description: "The Optional ID of an existing source to link to. Hidden in the admin UI.",
       },
     },
     {
@@ -59,8 +59,8 @@ export const FootnoteBlock: Block = {
     singularName: "FootnoteBlock",
   },
   labels: {
-    singular: "Footnote",
-    plural: "Footnotes",
+    singular: "Source",
+    plural: "Sources",
   },
   admin: {
     components: {

--- a/src/fields/footnotes.ts
+++ b/src/fields/footnotes.ts
@@ -51,8 +51,8 @@ export const footnoteFields = ({ component = {} }: FootnoteFieldOverrides = {}):
       type: "textarea",
       required: true,
       admin: {
-        description: "Footnote text.",
-        placeholder: "Enter footnote text here...",
+        description: "Source text.",
+        placeholder: "Enter source text here...",
         rows: 3,
         ...note.admin,
       },
@@ -73,7 +73,7 @@ export const footnoteFields = ({ component = {} }: FootnoteFieldOverrides = {}):
       defaultValue: false,
       required: true,
       admin: {
-        description: "Optionally add a source link to the footnote.",
+        description: "Optionally add a source link to the source.",
         ...attributionEnabled.admin,
       },
     },


### PR DESCRIPTION
## Summary
- rename reader-facing Footnote tooltip copy to Source
- rename Payload admin labels, descriptions, previews, notices, and selector copy to Source/Sources
- keep all internal identifiers, block slugs, field names, component names, and data-layer structures unchanged

Closes #867

## Validation
- reviewed the diff against the issue's copy-only scope
- 7 files changed, all limited to user-visible string literals
- no generated types, migrations, schema identifiers, or component names changed

I could not run the local pnpm validation commands in this environment; CI should provide the definitive lint/type/unit-test validation.