### PR TITLE
fix: restore active state in header navigation

### DIFF
--- a/src/components/MegaMenu/__tests__/isActivePath.test.ts
+++ b/src/components/MegaMenu/__tests__/isActivePath.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { isActivePath } from "../isActivePath"
+
+describe("isActivePath", () => {
+  it("matches the exact route", () => {
+    expect(isActivePath("/topics", "/topics")).toBe(true)
+  })
+
+  it("keeps a section active on nested routes", () => {
+    expect(isActivePath("/topics/ethics", "/topics")).toBe(true)
+  })
+
+  it("does not mark sibling routes active", () => {
+    expect(isActivePath("/authors", "/topics")).toBe(false)
+  })
+
+  it("treats the home route as exact-only", () => {
+    expect(isActivePath("/", "/")).toBe(true)
+    expect(isActivePath("/topics", "/")).toBe(false)
+  })
+
+  it("normalizes trailing slashes", () => {
+    expect(isActivePath("/topics", "/topics/")).toBe(true)
+  })
+
+  it("ignores external and missing URLs", () => {
+    expect(isActivePath("/topics", "https://example.com/topics")).toBe(false)
+    expect(isActivePath("/topics", null)).toBe(false)
+  })
+})

--- a/src/components/MegaMenu/index.tsx
+++ b/src/components/MegaMenu/index.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import {
   NavigationMenu,
   NavigationMenuItem,
@@ -5,13 +7,26 @@ import {
   NavigationMenuList,
 } from "@/components/ui/navigation-menu"
 import { type MenuField } from "@/payload-types"
+import { getLinkFieldUrl } from "@/utilities/getLinkFieldUrl"
+import { usePathname } from "next/navigation"
 import { CMSLink } from "../Link/CMSLink2"
 
 interface MegaMenuProps {
   menu?: MenuField
 }
 
+function isActivePath(pathname: string, url: string | null): boolean {
+  if (!url?.startsWith("/")) return false
+
+  const normalizedUrl = url === "/" ? url : url.replace(/\/+$/, "")
+  if (normalizedUrl === "/") return pathname === "/"
+
+  return pathname === normalizedUrl || pathname.startsWith(`${normalizedUrl}/`)
+}
+
 export function MegaMenu({ menu }: MegaMenuProps): React.ReactNode {
+  const pathname = usePathname()
+
   if (!menu) return null
   return (
     <div className="my-2 hidden w-full justify-center md:flex">
@@ -26,11 +41,18 @@ export function MegaMenu({ menu }: MegaMenuProps): React.ReactNode {
         <NavigationMenuLink>Link</NavigationMenuLink>
       </NavigationMenuContent>
     </NavigationMenuItem> */}
-          {menu.map((item) => (
-            <NavigationMenuItem key={item.id}>
-              <NavigationMenuLink className="py-1" render={<CMSLink link={item.link} />} />
-            </NavigationMenuItem>
-          ))}
+          {menu.map((item) => {
+            const url = getLinkFieldUrl(item.link)
+            return (
+              <NavigationMenuItem key={item.id}>
+                <NavigationMenuLink
+                  active={isActivePath(pathname, url)}
+                  className="py-1"
+                  render={<CMSLink link={item.link} />}
+                />
+              </NavigationMenuItem>
+            )
+          })}
         </NavigationMenuList>
       </NavigationMenu>
     </div>

--- a/src/components/MegaMenu/index.tsx
+++ b/src/components/MegaMenu/index.tsx
@@ -10,18 +10,10 @@ import { type MenuField } from "@/payload-types"
 import { getLinkFieldUrl } from "@/utilities/getLinkFieldUrl"
 import { usePathname } from "next/navigation"
 import { CMSLink } from "../Link/CMSLink2"
+import { isActivePath } from "./isActivePath"
 
 interface MegaMenuProps {
   menu?: MenuField
-}
-
-function isActivePath(pathname: string, url: string | null): boolean {
-  if (!url?.startsWith("/")) return false
-
-  const normalizedUrl = url === "/" ? url : url.replace(/\/+$/, "")
-  if (normalizedUrl === "/") return pathname === "/"
-
-  return pathname === normalizedUrl || pathname.startsWith(`${normalizedUrl}/`)
 }
 
 export function MegaMenu({ menu }: MegaMenuProps): React.ReactNode {

--- a/src/components/MegaMenu/isActivePath.ts
+++ b/src/components/MegaMenu/isActivePath.ts
@@ -1,0 +1,8 @@
+export function isActivePath(pathname: string, url: string | null): boolean {
+  if (!url?.startsWith("/")) return false
+
+  const normalizedUrl = url === "/" ? url : url.replace(/\/+$/, "")
+  if (normalizedUrl === "/") return pathname === "/"
+
+  return pathname === normalizedUrl || pathname.startsWith(`${normalizedUrl}/`)
+}

--- a/tests/e2e/author-card.spec.ts
+++ b/tests/e2e/author-card.spec.ts
@@ -8,7 +8,12 @@ import { waitForStableBox, waitForStableRender } from "./helpers"
 test("author card renders social media links @visual", async ({ page }, testInfo) => {
   await page.goto("/authors")
 
-  const card = page.locator('[data-slot="card"]').filter({ hasText: "Teagan Wordsmith" })
+  // The authors view can render the same card in responsive layouts, with only
+  // one copy visible at the active viewport. Scope the visual assertion to the
+  // rendered card so Playwright strict mode does not fail on hidden duplicates.
+  const card = page
+    .locator('[data-slot="card"]:visible')
+    .filter({ hasText: "Teagan Wordsmith" })
   await expect(card).toBeVisible()
 
   // Functional check (runs on every project, even when screenshots are skipped


### PR DESCRIPTION
Closes #617

Restores active navigation state in the MegaMenu using Base UI's `active` prop and adds unit tests for exact, nested, root, trailing-slash, and external-link route matching.

## CI follow-up
The first Playwright run failed in the pre-existing `author-card.spec.ts` test because its locator matched two responsive copies of the same seeded author card (one hidden, one visible), causing a Playwright strict-mode violation. The application behavior under this PR was not the source of that failure: 26/27 E2E tests passed and the core CI workflow was green.

This branch now scopes that E2E locator to the visible card only, preserving the existing assertions while avoiding the hidden duplicate.

CI should provide the definitive validation for the updated head.