### PR TITLE
test: add coverage for pure utility helpers

### DIFF
--- a/src/utilities/__tests__/deepMerge.test.ts
+++ b/src/utilities/__tests__/deepMerge.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import deepMerge, { isObject } from "../deepMerge"
+
+describe("deepMerge", () => {
+  it("merges nested objects while preserving untouched target keys", () => {
+    const target = {
+      title: "Original",
+      meta: { description: "Old", image: "hero.jpg" },
+    }
+    const source = {
+      meta: { description: "Updated" },
+    }
+
+    expect(deepMerge(target, source)).toEqual({
+      title: "Original",
+      meta: { description: "Updated", image: "hero.jpg" },
+    })
+  })
+
+  it("adds nested objects that do not exist on the target", () => {
+    expect(deepMerge({ title: "Post" }, { meta: { description: "Summary" } })).toEqual({
+      title: "Post",
+      meta: { description: "Summary" },
+    })
+  })
+
+  it("replaces arrays and primitive values from the source", () => {
+    const target = { tags: ["old"], published: false }
+    const source = { tags: ["new", "featured"], published: true }
+
+    expect(deepMerge(target, source)).toEqual(source)
+  })
+
+  it("does not mutate the target object", () => {
+    const target = { nested: { value: 1 } }
+
+    deepMerge(target, { nested: { value: 2 } })
+
+    expect(target).toEqual({ nested: { value: 1 } })
+  })
+})
+
+describe("isObject", () => {
+  it("accepts object values and rejects arrays and primitives", () => {
+    expect(isObject({})).toBe(true)
+    expect(isObject([])).toBe(false)
+    expect(isObject("value")).toBe(false)
+    expect(isObject(42)).toBe(false)
+  })
+})

--- a/src/utilities/__tests__/formatDateTime.test.ts
+++ b/src/utilities/__tests__/formatDateTime.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { formatDateTime } from "../formatDateTime"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("formatDateTime", () => {
+  it("formats an ISO timestamp as a readable calendar date", () => {
+    expect(formatDateTime("2026-08-23T10:30:00.000Z")).toBe("August 23, 2026")
+  })
+
+  it("handles single-digit days without zero padding", () => {
+    expect(formatDateTime("2026-01-05T12:00:00.000Z")).toBe("January 5, 2026")
+  })
+
+  it("falls back to the current date when the timestamp is empty", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-03-14T12:00:00.000Z"))
+
+    expect(formatDateTime("")).toBe("March 14, 2026")
+  })
+})

--- a/src/utilities/__tests__/formatDateTime.test.ts
+++ b/src/utilities/__tests__/formatDateTime.test.ts
@@ -6,17 +6,17 @@ afterEach(() => {
 })
 
 describe("formatDateTime", () => {
-  it("formats an ISO timestamp as a readable calendar date", () => {
-    expect(formatDateTime("2026-08-23T10:30:00.000Z")).toBe("August 23, 2026")
+  it("formats a timestamp as a readable calendar date", () => {
+    expect(formatDateTime("2026-08-23T12:00:00")).toBe("August 23, 2026")
   })
 
   it("handles single-digit days without zero padding", () => {
-    expect(formatDateTime("2026-01-05T12:00:00.000Z")).toBe("January 5, 2026")
+    expect(formatDateTime("2026-01-05T12:00:00")).toBe("January 5, 2026")
   })
 
   it("falls back to the current date when the timestamp is empty", () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date("2026-03-14T12:00:00.000Z"))
+    vi.setSystemTime(new Date(2026, 2, 14, 12, 0, 0))
 
     expect(formatDateTime("")).toBe("March 14, 2026")
   })

--- a/src/utilities/__tests__/toKebabCase.test.ts
+++ b/src/utilities/__tests__/toKebabCase.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { toKebabCase } from "../toKebabCase"
+
+describe("toKebabCase", () => {
+  it("converts camelCase to kebab-case", () => {
+    expect(toKebabCase("heroImageAlt")).toBe("hero-image-alt")
+  })
+
+  it("converts whitespace-separated words", () => {
+    expect(toKebabCase("Featured Article Title")).toBe("featured-article-title")
+  })
+
+  it("handles mixed camelCase and whitespace", () => {
+    expect(toKebabCase("articleHero FeaturedImage")).toBe("article-hero-featured-image")
+  })
+
+  it("collapses consecutive whitespace into one separator", () => {
+    expect(toKebabCase("one   two\tthree")).toBe("one-two-three")
+  })
+
+  it("returns an empty string for empty input", () => {
+    expect(toKebabCase("")).toBe("")
+  })
+})


### PR DESCRIPTION
## Summary
- add unit coverage for `deepMerge` and `isObject`
- add unit coverage for `toKebabCase`
- add timezone-safe unit coverage for `formatDateTime`

Part of #660

## Coverage
The tests exercise nested merges, source overrides, immutability, camelCase/whitespace conversion, empty input, date formatting, and the empty-timestamp fallback.

No production code is changed. CI should provide the definitive validation.